### PR TITLE
support travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+
+script: phpunit
+
+before_script:
+ - composer install --dev


### PR DESCRIPTION
この`.travis.yml`ファイルを追加して、travis-ci.orgにgithubのアカウントでログインしてごにょごにょ設定すると、githubにコミットするたびに、以下のようにPHPの5.3〜5.5でテストされるようになります。テストに失敗したらメールが飛んで超便利。

https://travis-ci.org/takahashim/DenDenMarkdown

（さっきのphpunit.xmlはこれのための設定なのでした）
